### PR TITLE
Update TCPClientSingle.ino to support additional Arduino models

### DIFF
--- a/examples/TCPClientSingle/TCPClientSingle.ino
+++ b/examples/TCPClientSingle/TCPClientSingle.ino
@@ -60,7 +60,7 @@ void setup(void)
  
 void loop(void)
 {
-    uint8_t buffer[1024] = {0};
+    uint8_t buffer[128] = {0};
     
     if (wifi.createTCP(HOST_NAME, HOST_PORT)) {
         Serial.print("create tcp ok\r\n");


### PR DESCRIPTION
The current buffer size of 1024 silently crashes on Arduino Unos, Nanos, and Micros. A buffer size of 128, which is what is used in the TCPClientMultiple.ino example, works splendidly.
