### PR TITLE
ESP8266::recv  -  speed optimisation

### DIFF
--- a/ESP8266.cpp
+++ b/ESP8266.cpp
@@ -286,6 +286,7 @@ uint32_t ESP8266::recv(uint8_t mux_id, uint8_t *buffer, uint32_t buffer_size, ui
 
 uint32_t ESP8266::recv(uint8_t *coming_mux_id, uint8_t *buffer, uint32_t buffer_size, uint32_t timeout)
 {
+	if(!m_puart->available()) return 0; // don't enter while loop if there is no serial data available
     return recvPkg(buffer, buffer_size, NULL, timeout, coming_mux_id);
 }
 


### PR DESCRIPTION
function was entering while loop and timing out even if there was no data available or data was to be sent (probably most of the time). This optimisation uses an IF statement to check if data is available before entering the while loop.
